### PR TITLE
feat: full branded footer — brand column, shop menu, signup, jumbo wordmark

### DIFF
--- a/sections/footer-group.json
+++ b/sections/footer-group.json
@@ -5,14 +5,138 @@
     "footer_section": {
       "type": "footer",
       "blocks": {
+        "columns": {
+          "type": "group",
+          "settings": {
+            "content_direction": "row",
+            "vertical_on_mobile": true,
+            "horizontal_alignment": "space-between",
+            "vertical_alignment": "flex-start",
+            "gap": 48,
+            "width": "fill",
+            "width_mobile": "fill",
+            "inherit_color_scheme": true
+          },
+          "blocks": {
+            "brand": {
+              "type": "group",
+              "settings": {
+                "content_direction": "column",
+                "horizontal_alignment_flex_direction_column": "flex-start",
+                "gap": 12,
+                "width": "custom",
+                "custom_width": 32,
+                "width_mobile": "fill",
+                "inherit_color_scheme": true
+              },
+              "blocks": {
+                "brand_heading": {
+                  "type": "text",
+                  "settings": {
+                    "text": "<h3>Yard Microwaves</h3>",
+                    "type_preset": "h3",
+                    "width": "100%",
+                    "max_width": "normal",
+                    "alignment": "left"
+                  }
+                },
+                "brand_tagline": {
+                  "type": "text",
+                  "settings": {
+                    "text": "<p>We do not make grills. We never have. Please stop asking.</p>",
+                    "type_preset": "paragraph",
+                    "width": "100%",
+                    "max_width": "narrow",
+                    "alignment": "left"
+                  }
+                }
+              },
+              "block_order": ["brand_heading", "brand_tagline"]
+            },
+            "shop_menu": {
+              "type": "menu",
+              "settings": {
+                "menu": "main-menu",
+                "heading": "Shop",
+                "heading_preset": "h6",
+                "link_preset": "paragraph",
+                "menu_spacing": 12,
+                "inherit_color_scheme": true
+              }
+            },
+            "signup": {
+              "type": "group",
+              "settings": {
+                "content_direction": "column",
+                "horizontal_alignment_flex_direction_column": "flex-start",
+                "gap": 16,
+                "width": "custom",
+                "custom_width": 36,
+                "width_mobile": "fill",
+                "inherit_color_scheme": true
+              },
+              "blocks": {
+                "signup_form": {
+                  "type": "email-signup",
+                  "settings": {
+                    "heading": "Get plugged in",
+                    "heading_preset": "h6",
+                    "width": "fill",
+                    "inherit_color_scheme": true,
+                    "border_style": "underline",
+                    "border_width": 1,
+                    "border_radius": 0,
+                    "display_type": "text",
+                    "label": "Plug in",
+                    "style_class": "button",
+                    "integrated_button": false
+                  }
+                },
+                "signup_tagline": {
+                  "type": "text",
+                  "settings": {
+                    "text": "<p>Drops, deals, and hot links — straight to your inbox. Extension cords not included.</p>",
+                    "type_preset": "paragraph",
+                    "width": "100%",
+                    "max_width": "narrow",
+                    "alignment": "left"
+                  }
+                }
+              },
+              "block_order": ["signup_form", "signup_tagline"]
+            }
+          },
+          "block_order": ["brand", "shop_menu", "signup"]
+        },
+        "jumbo": {
+          "type": "jumbo-text",
+          "settings": {
+            "text": "Yard Microwaves",
+            "font": "heading",
+            "alignment": "left",
+            "line_height": "0.8",
+            "letter_spacing": "-0.03em",
+            "case": "uppercase",
+            "text_effect": "reveal",
+            "animation_repeat": false
+          }
+        },
         "footer_utilities": {
           "type": "footer-utilities",
           "settings": {},
           "blocks": {}
         }
       },
-      "block_order": ["footer_utilities"],
-      "settings": {}
+      "block_order": ["columns", "jumbo", "footer_utilities"],
+      "settings": {
+        "content_direction": "column",
+        "horizontal_alignment_flex_direction_column": "flex-start",
+        "gap": 48,
+        "section_width": "page-width",
+        "color_scheme": "scheme-5",
+        "padding-block-start": 64,
+        "padding-block-end": 20
+      }
     }
   },
   "order": ["footer_section"]


### PR DESCRIPTION
## What

Replaces the utilities-only footer (all #26 shipped was policy links + copyright + socials) with a complete site-wide footer, dark **scheme-5**, composed entirely from stock Fabric blocks in `footer-group.json` — no new Liquid.

**Layout, top to bottom:**
1. **Columns row** (stacks on mobile):
   - **Brand** — "Yard Microwaves" + *"We do not make grills. We never have. Please stop asking."*
   - **Shop menu** — renders `main-menu` (same links as the header)
   - **Email signup** — heading *"Get plugged in"*, button *"Plug in"*, underline input style, tagline *"Drops, deals, and hot links — straight to your inbox. Extension cords not included."*
2. **Jumbo wordmark** — full-width YARD MICROWAVES, heading font, scroll-reveal
3. **Footer utilities** — the existing auto policy links, © copyright, and social icons bar

## Verification

- `shopify theme check --fail-level error` passes; **0 offenses** on `footer-group.json` (the 107 pre-existing warnings are the #93 debt, untouched)
- ⚠️ **Not browser-verified** — Shopify CLI needs interactive device auth this session cannot do. Merging deploys to the **staging theme** (`deploy-staging.yml`); preview there before releasing to live.
- All copy/menus/spacing are editable in the theme customizer — but per the repo rule, make keeper edits here in the repo, not on the live theme.

Copy is pulled from the vault brand docs (YM Slogans: "Extension cords not included"; Braindump: "we do not make grills").

🤖 Generated with [Claude Code](https://claude.com/claude-code)