### PR TITLE
feat: hot-links-only footer + smaller sausage wordmarks

### DIFF
--- a/assets/ym-custom.css
+++ b/assets/ym-custom.css
@@ -1201,6 +1201,9 @@ html { scroll-behavior: smooth; }
      so the sausage bodies sit on the image's midline. */
   top: 51%;
   width: 26%;
+  /* Definite height (tracks the chain image) so the wordmark's
+     percentage height sizing below can resolve. */
+  height: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1228,9 +1231,9 @@ html { scroll-behavior: smooth; }
      height regardless of source aspect ratio (TIKTOK's PNG is more
      compact than INSTAGRAM/FACEBOOK, so width-based sizing would
      blow it up vertically). max-width keeps it inside its sausage. */
-  height: 45%;
+  height: 30%;
   width: auto;
-  max-width: 80%;
+  max-width: 70%;
   object-fit: contain;
   /* Wordmarks stay their native cream — the chain art is now full-color
      orange sausages, so an orange recolor would disappear into the body. */

--- a/sections/footer-group.json
+++ b/sections/footer-group.json
@@ -2,142 +2,57 @@
   "type": "footer",
   "name": "Footer",
   "sections": {
+    "ym_footer_cta": {
+      "type": "ym-footer-cta",
+      "settings": {
+        "heading": "HOT LINKS"
+      },
+      "blocks": {
+        "social_instagram": {
+          "type": "social_link",
+          "settings": {
+            "platform": "Instagram",
+            "url": "https://instagram.com/yardmicrowaves"
+          }
+        },
+        "social_facebook": {
+          "type": "social_link",
+          "settings": {
+            "platform": "Facebook",
+            "url": "https://facebook.com/yardmicrowaves"
+          }
+        },
+        "social_tiktok": {
+          "type": "social_link",
+          "settings": {
+            "platform": "TikTok",
+            "url": "https://tiktok.com/@yardmicrowaves"
+          }
+        }
+      },
+      "block_order": [
+        "social_instagram",
+        "social_facebook",
+        "social_tiktok"
+      ]
+    },
     "footer_section": {
       "type": "footer",
       "blocks": {
-        "columns": {
-          "type": "group",
-          "settings": {
-            "content_direction": "row",
-            "vertical_on_mobile": true,
-            "horizontal_alignment": "space-between",
-            "vertical_alignment": "flex-start",
-            "gap": 48,
-            "width": "fill",
-            "width_mobile": "fill",
-            "inherit_color_scheme": true
-          },
-          "blocks": {
-            "brand": {
-              "type": "group",
-              "settings": {
-                "content_direction": "column",
-                "horizontal_alignment_flex_direction_column": "flex-start",
-                "gap": 12,
-                "width": "custom",
-                "custom_width": 32,
-                "width_mobile": "fill",
-                "inherit_color_scheme": true
-              },
-              "blocks": {
-                "brand_heading": {
-                  "type": "text",
-                  "settings": {
-                    "text": "<h3>Yard Microwaves</h3>",
-                    "type_preset": "h3",
-                    "width": "100%",
-                    "max_width": "normal",
-                    "alignment": "left"
-                  }
-                },
-                "brand_tagline": {
-                  "type": "text",
-                  "settings": {
-                    "text": "<p>We do not make grills. We never have. Please stop asking.</p>",
-                    "type_preset": "paragraph",
-                    "width": "100%",
-                    "max_width": "narrow",
-                    "alignment": "left"
-                  }
-                }
-              },
-              "block_order": ["brand_heading", "brand_tagline"]
-            },
-            "shop_menu": {
-              "type": "menu",
-              "settings": {
-                "menu": "main-menu",
-                "heading": "Shop",
-                "heading_preset": "h6",
-                "link_preset": "paragraph",
-                "menu_spacing": 12,
-                "inherit_color_scheme": true
-              }
-            },
-            "signup": {
-              "type": "group",
-              "settings": {
-                "content_direction": "column",
-                "horizontal_alignment_flex_direction_column": "flex-start",
-                "gap": 16,
-                "width": "custom",
-                "custom_width": 36,
-                "width_mobile": "fill",
-                "inherit_color_scheme": true
-              },
-              "blocks": {
-                "signup_form": {
-                  "type": "email-signup",
-                  "settings": {
-                    "heading": "Get plugged in",
-                    "heading_preset": "h6",
-                    "width": "fill",
-                    "inherit_color_scheme": true,
-                    "border_style": "underline",
-                    "border_width": 1,
-                    "border_radius": 0,
-                    "display_type": "text",
-                    "label": "Plug in",
-                    "style_class": "button",
-                    "integrated_button": false
-                  }
-                },
-                "signup_tagline": {
-                  "type": "text",
-                  "settings": {
-                    "text": "<p>Drops, deals, and hot links — straight to your inbox. Extension cords not included.</p>",
-                    "type_preset": "paragraph",
-                    "width": "100%",
-                    "max_width": "narrow",
-                    "alignment": "left"
-                  }
-                }
-              },
-              "block_order": ["signup_form", "signup_tagline"]
-            }
-          },
-          "block_order": ["brand", "shop_menu", "signup"]
-        },
-        "jumbo": {
-          "type": "jumbo-text",
-          "settings": {
-            "text": "Yard Microwaves",
-            "font": "heading",
-            "alignment": "left",
-            "line_height": "0.8",
-            "letter_spacing": "-0.03em",
-            "case": "uppercase",
-            "text_effect": "reveal",
-            "animation_repeat": false
-          }
-        },
         "footer_utilities": {
           "type": "footer-utilities",
           "settings": {},
           "blocks": {}
         }
       },
-      "block_order": ["columns", "jumbo", "footer_utilities"],
-      "settings": {
-        "content_direction": "column",
-        "horizontal_alignment_flex_direction_column": "flex-start",
-        "gap": 48,
-        "section_width": "page-width",
-        "color_scheme": "scheme-5",
-        "padding-block-start": 64,
-        "padding-block-end": 20
-      }
+      "block_order": [
+        "footer_utilities"
+      ],
+      "settings": {}
     }
   },
-  "order": ["footer_section"]
+  "order": [
+    "ym_footer_cta",
+    "footer_section"
+  ]
 }

--- a/templates/index.json
+++ b/templates/index.json
@@ -31,7 +31,7 @@
         "ingredient_2": {
           "type": "ingredient",
           "settings": {
-            "text": "Heavy weight material — 100% combed cotton"
+            "text": "Heavy weight material \u2014 100% combed cotton"
           }
         },
         "ingredient_3": {
@@ -101,7 +101,10 @@
           "settings": {}
         }
       },
-      "block_order": ["rp_thumb_1", "rp_thumb_2"]
+      "block_order": [
+        "rp_thumb_1",
+        "rp_thumb_2"
+      ]
     },
     "ym_quality_banner": {
       "type": "ym-quality-banner",
@@ -131,37 +134,10 @@
           "settings": {}
         }
       },
-      "block_order": ["ss_thumb_1", "ss_thumb_2"]
-    },
-    "ym_footer_cta": {
-      "type": "ym-footer-cta",
-      "settings": {
-        "heading": "HOT LINKS"
-      },
-      "blocks": {
-        "social_instagram": {
-          "type": "social_link",
-          "settings": {
-            "platform": "Instagram",
-            "url": "https://instagram.com/yardmicrowaves"
-          }
-        },
-        "social_facebook": {
-          "type": "social_link",
-          "settings": {
-            "platform": "Facebook",
-            "url": "https://facebook.com/yardmicrowaves"
-          }
-        },
-        "social_tiktok": {
-          "type": "social_link",
-          "settings": {
-            "platform": "TikTok",
-            "url": "https://tiktok.com/@yardmicrowaves"
-          }
-        }
-      },
-      "block_order": ["social_instagram", "social_facebook", "social_tiktok"]
+      "block_order": [
+        "ss_thumb_1",
+        "ss_thumb_2"
+      ]
     }
   },
   "order": [
@@ -171,7 +147,6 @@
     "ym_story",
     "ym_showcase_rubplug",
     "ym_quality_banner",
-    "ym_showcase_smokesig",
-    "ym_footer_cta"
+    "ym_showcase_smokesig"
   ]
 }


### PR DESCRIPTION
Per Rich: the footer should be just the HOT LINKS.

- Reverts the footer section to its pre-#107 utilities-only state (brand column, Shop menu, signup, and jumbo wordmark removed; policy links + copyright bar kept)
- Moves the `ym-footer-cta` HOT LINKS section from the homepage template into `footer-group.json`, so the sausage chain is now the sitewide footer (configured social URLs carried over)
- Shrinks the social wordmarks: link boxes get a definite height so height-based sizing actually resolves — all three wordmarks now render at a matching, smaller letter height (30% of chain height) instead of being width-capped, which had oversized TIKTOK

Verified in a headless Chromium harness at 1440px and 390px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)