### PR TITLE
feat(email): Klaviyo templates built from the theme's own assets

### DIFF
--- a/email/.gitignore
+++ b/email/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+build/

--- a/email/assets.json
+++ b/email/assets.json
@@ -1,0 +1,370 @@
+{
+ "paper-bg": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/b2df05d4-4dd6-427a-924d-058e08fe965b.jpeg",
+  "id": "361398925",
+  "hash": "c65530d42794",
+  "w": 600,
+  "h": 900,
+  "file": "paper-bg.jpg"
+ },
+ "badge-logo": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/a57c07cd-635b-4fd2-8ce3-ed26ee5fb348.png",
+  "id": "361398926",
+  "hash": "06633ad2a5f5",
+  "w": 200,
+  "h": 109,
+  "file": "badge-logo.png"
+ },
+ "logo-white": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/2b80f130-74c4-497a-8b1d-4b231c08cbc6.png",
+  "id": "361398927",
+  "hash": "fa12432ba805",
+  "w": 176,
+  "h": 91,
+  "file": "logo-white.png"
+ },
+ "nav-shop": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/708200f5-cbcc-4f06-ae5b-dd549d51a163.png",
+  "id": "361398928",
+  "hash": "2a65bd646f92",
+  "w": 82,
+  "h": 53,
+  "file": "nav-shop.png"
+ },
+ "nav-story": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/4a96e60e-ef46-4969-8bdd-17e40f1cff41.png",
+  "id": "361398929",
+  "hash": "44458e5a5d16",
+  "w": 98,
+  "h": 53,
+  "file": "nav-story.png"
+ },
+ "h-welcome-new": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/b2e2dd7d-fcbc-4ecd-87ff-85e5d0119415.png",
+  "id": "361398931",
+  "hash": "4a734c6e2e43",
+  "w": 393,
+  "h": 64,
+  "file": "h-welcome-new.png"
+ },
+ "h-welcome-exist": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/f391bf9c-a57c-4f04-bdea-3b6a3e335705.png",
+  "id": "361398933",
+  "hash": "52d6b0435a70",
+  "w": 356,
+  "h": 64,
+  "file": "h-welcome-exist.png"
+ },
+ "h-follow": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/dddbb356-bdac-4430-9fb7-be6a2e3887bf.png",
+  "id": "361398934",
+  "hash": "d2226ac73f04",
+  "w": 295,
+  "h": 64,
+  "file": "h-follow.png"
+ },
+ "h-review-req": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/5af200ee-445a-4112-9b59-396fc90df89a.png",
+  "id": "361398935",
+  "hash": "f8dcf3aa4b5d",
+  "w": 361,
+  "h": 64,
+  "file": "h-review-req.png"
+ },
+ "h-review-rem": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/0e0eac80-96be-40db-b923-51861842a7d9.png",
+  "id": "361398937",
+  "hash": "10c682acd9ac",
+  "w": 463,
+  "h": 64,
+  "file": "h-review-rem.png"
+ },
+ "h-shipping": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/c3080bae-16a1-4499-a3f6-194c7ce29984.png",
+  "id": "361398939",
+  "hash": "6d5f221189df",
+  "w": 274,
+  "h": 64,
+  "file": "h-shipping.png"
+ },
+ "h-order": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/39a19e0f-96da-4b0a-a488-5621e906b17e.png",
+  "id": "361398940",
+  "hash": "8b3c0ce40205",
+  "w": 440,
+  "h": 64,
+  "file": "h-order.png"
+ },
+ "h-cart-1": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/bf712c0b-ffea-4f16-9208-df8800760251.png",
+  "id": "361398941",
+  "hash": "c121e91cd793",
+  "w": 502,
+  "h": 116,
+  "file": "h-cart-1.png"
+ },
+ "h-cart-2": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/1e060008-aaae-41b6-8a76-ef923b420264.png",
+  "id": "361398942",
+  "hash": "c7293eacdf0b",
+  "w": 502,
+  "h": 116,
+  "file": "h-cart-2.png"
+ },
+ "h-browse": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/e27b5aed-b91a-44a6-91b6-9cea86282d73.png",
+  "id": "361398943",
+  "hash": "941e40544ed1",
+  "w": 502,
+  "h": 116,
+  "file": "h-browse.png"
+ },
+ "b-shop-now": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/3266e152-ca5c-489a-83fe-b21f0ea7e6a5.png",
+  "id": "361398944",
+  "hash": "48d6e1484191",
+  "w": 100,
+  "h": 34,
+  "file": "b-shop-now.png"
+ },
+ "b-back-to-cart": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/784efdd0-d298-4256-b994-cc95fc8e0862.png",
+  "id": "361398945",
+  "hash": "1da3209f41b8",
+  "w": 147,
+  "h": 34,
+  "file": "b-back-to-cart.png"
+ },
+ "b-track-package": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/b563f9bc-78f2-4f3c-9555-3315bf3943cf.png",
+  "id": "361398946",
+  "hash": "a36e7cea0b0d",
+  "w": 190,
+  "h": 34,
+  "file": "b-track-package.png"
+ },
+ "b-track-order": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/944843fa-019b-4ade-ac5e-d343d7fe2ea3.png",
+  "id": "361398947",
+  "hash": "3f37ec19d88b",
+  "w": 172,
+  "h": 34,
+  "file": "b-track-order.png"
+ },
+ "b-follow-ig": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/5a35fa24-be43-4c3e-887e-bf0544624ab5.png",
+  "id": "361398948",
+  "hash": "0f083c69a0a3",
+  "w": 226,
+  "h": 34,
+  "file": "b-follow-ig.png"
+ },
+ "b-leave-review": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/8344f027-2097-4bb8-abff-3f1df9239302.png",
+  "id": "361398949",
+  "hash": "d1368e56d5ef",
+  "w": 139,
+  "h": 34,
+  "file": "b-leave-review.png"
+ },
+ "b-our-story": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/b00e618a-4a0b-472d-93a9-7361344bde28.png",
+  "id": "361398950",
+  "hash": "bd97965a86b4",
+  "w": 94,
+  "h": 34,
+  "file": "b-our-story.png"
+ },
+ "pill-shop-now": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/b1789fa0-7ace-4884-9fdb-3c09b2c9dc5d.png",
+  "id": "361398952",
+  "hash": "cec7e9704c76",
+  "w": 176,
+  "h": 56,
+  "file": "pill-shop-now.png"
+ },
+ "pill-back-to-cart": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/3c2a27a3-4d84-42a9-aa2b-2c23e1f8cb63.png",
+  "id": "361398953",
+  "hash": "4f50500f17b6",
+  "w": 223,
+  "h": 56,
+  "file": "pill-back-to-cart.png"
+ },
+ "pill-track-package": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/755b41cd-9c9e-4d69-ba32-bd28c987e60f.png",
+  "id": "361398954",
+  "hash": "5d4dc7f03f66",
+  "w": 266,
+  "h": 56,
+  "file": "pill-track-package.png"
+ },
+ "pill-track-order": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/440ad0ec-e629-43a4-83f2-7d0b21c26ba2.png",
+  "id": "361398955",
+  "hash": "c902bdb8d8ac",
+  "w": 248,
+  "h": 56,
+  "file": "pill-track-order.png"
+ },
+ "pill-follow-ig": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/8a98957d-69ec-42b9-a77c-4db3b324e12b.png",
+  "id": "361398956",
+  "hash": "afe41f3b6b59",
+  "w": 302,
+  "h": 56,
+  "file": "pill-follow-ig.png"
+ },
+ "pill-leave-review": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/8441aa50-56eb-4fc0-b28a-6b72d3cd732a.png",
+  "id": "361398957",
+  "hash": "3b6e76e7c223",
+  "w": 215,
+  "h": 56,
+  "file": "pill-leave-review.png"
+ },
+ "pill-our-story": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/1339aef1-e65b-4090-a196-191d274c642d.png",
+  "id": "361398958",
+  "hash": "9c5bceb00ec1",
+  "w": 170,
+  "h": 56,
+  "file": "pill-our-story.png"
+ },
+ "hero-smoker": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/fcc95f50-439f-4802-83a7-8202b15c4a92.png",
+  "id": "361398959",
+  "hash": "5c4c445dab46",
+  "w": 600,
+  "h": 330,
+  "file": "hero-smoker.png"
+ },
+ "showcase": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/a76fe9e7-a6cd-4e18-841d-676d63448593.png",
+  "id": "361398960",
+  "hash": "ec4893276eee",
+  "w": 600,
+  "h": 580,
+  "file": "showcase.png"
+ },
+ "quality-band": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/e280f4fb-48a5-436d-8375-cae41bbfbf2c.png",
+  "id": "361398961",
+  "hash": "15d87d5b9f9d",
+  "w": 600,
+  "h": 92,
+  "file": "quality-band.png"
+ },
+ "freeship": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/f0150b16-06ee-4d47-8948-92c0d059a22b.png",
+  "id": "361398962",
+  "hash": "6882f35fe99f",
+  "w": 170,
+  "h": 170,
+  "file": "freeship.png"
+ },
+ "recipe-card": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/1d24df3b-6613-44af-8a1b-bbeb590b8752.png",
+  "id": "361398963",
+  "hash": "56db40cd788e",
+  "w": 600,
+  "h": 249,
+  "file": "recipe-card.png"
+ },
+ "tagline-brisket": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/0a4987b8-e08a-4b5a-86f5-249796e5c19f.png",
+  "id": "361398966",
+  "hash": "1ba36555904a",
+  "w": 260,
+  "h": 306,
+  "file": "tagline-brisket.png"
+ },
+ "torn-to-dark": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/61070ad3-2f50-46a1-b481-6aa879454f77.png",
+  "id": "361398973",
+  "hash": "0772f143d18a",
+  "w": 600,
+  "h": 100,
+  "file": "torn-to-dark.png"
+ },
+ "hotlinks-heading": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/26c71521-5534-4872-8ce3-1db67aeca4da.png",
+  "id": "361398975",
+  "hash": "6895d9a614c9",
+  "w": 179,
+  "h": 42,
+  "file": "hotlinks-heading.png"
+ },
+ "hotlink-instagram": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/b200683a-1a35-4fbe-94fa-36ee454279c4.png",
+  "id": "361398976",
+  "hash": "9a7b2a1f6274",
+  "w": 196,
+  "h": 100,
+  "file": "hotlink-instagram.png"
+ },
+ "hotlink-facebook": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/f2d7c54b-cfaf-497d-8485-1a2d2cf41569.png",
+  "id": "361398978",
+  "hash": "8e22a941d1e2",
+  "w": 196,
+  "h": 100,
+  "file": "hotlink-facebook.png"
+ },
+ "hotlink-tiktok": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/f5cd9682-1213-4535-a912-879f98bd5528.png",
+  "id": "361398979",
+  "hash": "cb5959bf4e47",
+  "w": 196,
+  "h": 100,
+  "file": "hotlink-tiktok.png"
+ },
+ "mascot": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/9f769c21-26df-4b48-8996-fa7946bf0ae4.png",
+  "id": "361398980",
+  "hash": "d74f63a55049",
+  "w": 250,
+  "h": 180,
+  "file": "mascot.png"
+ },
+ "story-collage": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/416df2cc-c6fb-4e3c-996c-97c21c21ca14.png",
+  "id": "361398983",
+  "hash": "762bac1c527f",
+  "w": 320,
+  "h": 400,
+  "file": "story-collage.png"
+ },
+ "pioneers-photo": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/b1d1d813-87ca-4af0-a1e3-332a377276d1.png",
+  "id": "361398984",
+  "hash": "d07acc4c2a20",
+  "w": 300,
+  "h": 327,
+  "file": "pioneers-photo.png"
+ },
+ "pellets": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/2d35bf27-f1c9-4754-8b29-4a6b7b262c4d.png",
+  "id": "361398985",
+  "hash": "1d5901402ce8",
+  "w": 110,
+  "h": 54,
+  "file": "pellets.png"
+ },
+ "icon-smoke": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/90c8930d-5e8d-4974-ad03-7e96d1572157.png",
+  "id": "361398986",
+  "hash": "a1af098b8bd2",
+  "w": 42,
+  "h": 39,
+  "file": "icon-smoke.png"
+ },
+ "star": {
+  "url": "https://d3k81ch9hvuctc.cloudfront.net/company/V6xuPQ/images/38ab703a-927c-4093-8435-ef5bd34d3362.png",
+  "id": "361398988",
+  "hash": "f57ee83a0d2e",
+  "w": 40,
+  "h": 40,
+  "file": "star.png"
+ }
+}

--- a/email/build.mjs
+++ b/email/build.mjs
@@ -62,8 +62,10 @@ const small = (html) => block(html, `font-family:${COND};font-size:14px;line-hei
 /** Coupon callout — dashed olive ticket, Permanent-Marker-ish via condensed caps. */
 const coupon = (html) => block(`<table role="presentation" border="0" cellpadding="0" cellspacing="0" align="center" style="margin:6px auto 14px;"><tr><td align="center" style="border:2px dashed ${OLIVE};border-radius:8px;padding:12px 22px;font-family:${COND};font-size:16px;line-height:1.4;letter-spacing:.8px;text-transform:uppercase;color:${OLIVE};">${html}</td></tr></table>`, 'text-align:center;padding:0;');
 
-/** Editable body region (Klaviyo hybrid template). */
-const region = (blocks) => `<tr><td align="left" class="ym-pad" data-klaviyo-region="true" data-klaviyo-region-width-pixels="600" style="padding:10px 44px 4px;">${blocks.join('\n')}</td></tr>`;
+/** Body copy. Plain klaviyo-block divs, deliberately NOT inside a
+ *  data-klaviyo-region: Klaviyo rewrites region contents and strips the inline
+ *  typography (verified: 12 styled blocks → 4 after render). */
+const region = (blocks) => `<tr><td align="left" class="ym-pad" style="padding:10px 44px 4px;">${blocks.join('\n')}</td></tr>`;
 
 const showcase = () => row(picture('showcase', { w: 600, alt: 'Rub & Plug and Smoke Signal tees — relaxed fit, crew neck, heavy weight', href: SITE }), '6px 0 0');
 const quality = () => row(picture('quality-band', { w: 600, alt: 'Quality beyond compare. Preshrunk for perfection. Just like your brisket, our shirts exceed expectations. Guaranteed.' }), '4px 0 10px');
@@ -95,7 +97,7 @@ const shipItems = () => row(`{% if event.extra.line_items %}${lineItems({ priceE
 const totals = () => row(`<table role="presentation" border="0" cellpadding="0" cellspacing="0" align="right" style="font-family:${COND};font-size:16px;line-height:1.7;color:${INK};">
 <tr><td style="padding-right:18px;color:${OLIVE};text-transform:uppercase;letter-spacing:.5px;">Subtotal</td><td align="right">{{ event.extra.subtotal_price }}</td></tr>
 <tr><td style="padding-right:18px;color:${OLIVE};text-transform:uppercase;letter-spacing:.5px;">Shipping</td><td align="right">{{ event.extra.shipping_lines.0.price }}</td></tr>
-<tr><td style="padding-right:18px;color:${OLIVE};text-transform:uppercase;letter-spacing:.5px;font-weight:bold;">Total</td><td align="right" style="font-weight:bold;">{{ event|lookup:'$value' }}</td></tr>
+<tr><td style="padding-right:18px;color:${OLIVE};text-transform:uppercase;letter-spacing:.5px;font-weight:bold;">Total</td><td align="right" style="font-weight:bold;">{{ event.extra.total_price|default:event.extra.subtotal_price }}</td></tr>
 </table>`, '0 44px 12px');
 
 const addressBlock = (label, p) => `<div style="font-family:${COND};font-size:14px;line-height:1.5;color:${INK};"><div style="color:${OLIVE};text-transform:uppercase;letter-spacing:.6px;font-size:13px;padding-bottom:3px;">${label}</div>
@@ -117,13 +119,13 @@ const stars = () => row(`<div style="font-family:${COND};font-size:17px;line-hei
   `<td style="padding:0 4px;"><a href="{{ event.review_link }}?rating=${n}" target="_blank" style="display:block;">${picture('star', { w: 36, alt: `Rate it ${n} star${n > 1 ? 's' : ''}` })}</a></td>`).join('')}</tr></table>`, '4px 40px 16px');
 
 /** 3-up "trending" grid from Klaviyo's Shopify product feed. */
-const feedGrid = (title) => row(`<div style="font-family:${COND};font-size:15px;line-height:1.4;letter-spacing:.8px;text-transform:uppercase;color:${OLIVE};padding:0 0 12px;text-align:center;">${title}</div>
+const feedGrid = (title) => row(`{% if feeds.SHOP_POPULAR_ALL_CATEGORIES|index:0 %}<div style="font-family:${COND};font-size:15px;line-height:1.4;letter-spacing:.8px;text-transform:uppercase;color:${OLIVE};padding:0 0 12px;text-align:center;">${title}</div>
 <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%"><tr>${[0, 1, 2].map((i) => `
 <td width="33%" valign="top" align="center" style="padding:0 6px;">{% if feeds.SHOP_POPULAR_ALL_CATEGORIES|index:${i} %}{% with item=feeds.SHOP_POPULAR_ALL_CATEGORIES|index:${i} %}
 <a href="{{ item.url }}" target="_blank" style="display:block;text-decoration:none;"><img src="{{ item.image_full_url }}" width="160" alt="{{ item.title|safe }}" style="display:block;width:160px;max-width:100%;height:auto;border:0;border-radius:6px;margin:0 auto 8px;"/>
 <div style="font-family:${COND};font-size:14px;line-height:1.3;color:${INK};font-weight:bold;">{{ item.title|safe }}</div>
 <div style="font-family:${COND};font-size:14px;line-height:1.5;color:${OLIVE};">{{ item.price|default:'' }}</div></a>
-{% endwith %}{% endif %}</td>`).join('')}</tr></table>`, '8px 30px 14px');
+{% endwith %}{% endif %}</td>`).join('')}</tr></table>{% endif %}`, '8px 30px 14px');
 
 /** Dark HOT LINKS footer, torn paper edge on top — the theme's ym-footer-cta. */
 function footer() {
@@ -134,7 +136,7 @@ ${picture('hotlinks-heading', { alt: 'Hot links', style: 'margin:0 auto 2px;' })
 <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width:588px;"><tr>${hl('instagram', IG, 'Instagram')}${hl('facebook', FB, 'Facebook')}${hl('tiktok', TT, 'TikTok')}</tr></table>
 <div style="padding:18px 0 12px;">${picture('logo-white', { w: 132, alt: 'Yard Microwaves', href: SITE, style: 'margin:0 auto;' })}</div>
 <div style="font-family:${COND};font-size:14px;line-height:1.5;letter-spacing:1px;text-transform:uppercase;color:${CREAM};padding-bottom:12px;">Smoking meats. Chugging pilsners.<br/>Bringing families together.</div>
-<div style="font-family:${BODY};font-size:12px;line-height:1.75;color:#CBBFA2;">
+<div class="ym-foot" style="font-family:${BODY};font-size:12px;line-height:1.75;color:#CBBFA2;">
 <a href="${IG}" target="_blank" style="color:${PEACH};text-decoration:none;font-weight:bold;">@yardmicrowaves</a>&nbsp;&bull;&nbsp;<a href="${SITE}" target="_blank" style="color:${PEACH};text-decoration:none;font-weight:bold;">yardmicrowaves.com</a><br/>
 Yard Microwaves &middot; 24002 Via Fabricante #225, Mission Viejo, CA 92691<br/>
 You're getting this because you signed up at the Yard.<br/>
@@ -166,6 +168,7 @@ ul { margin:0 0 10px; padding-left:22px; }
 li { margin:0 0 4px; }
 h3, h4 { font-family:${COND}; color:${OLIVE}; text-transform:uppercase; letter-spacing:.6px; font-size:17px; line-height:1.3; margin:4px 0 8px; }
 table { border-collapse:collapse; }
+.ym-foot a { color:${PEACH}; }
 @media only screen and (max-width:620px) {
   .ym-container { width:100% !important; }
   .ym-pad { padding-left:16px !important; padding-right:16px !important; }

--- a/email/build.mjs
+++ b/email/build.mjs
@@ -1,0 +1,385 @@
+#!/usr/bin/env node
+/**
+ * Build the 12 Klaviyo email templates as table-based HTML from one shared
+ * skeleton. Reads assets.json (Klaviyo CDN urls written by `klaviyo.mjs
+ * upload`) and writes build/templates/<slug>.html + index.json.
+ *
+ * Design language = the theme's landing page, section for section:
+ *   header (The Shop / badge / Our Story) → Milenia headline → condensed
+ *   uppercase olive lede → body copy → red Milenia pill → butcher-paper
+ *   showcase / recipe card / quality band → torn edge → dark HOT LINKS footer.
+ *
+ * Templates are USER_DRAGGABLE: the copy sits in a Klaviyo region of text
+ * blocks so it stays editable in the Klaviyo editor; the chrome is fixed HTML.
+ */
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const A = JSON.parse(readFileSync(resolve(HERE, 'assets.json'), 'utf8'));
+const OUT = resolve(HERE, 'build', 'templates');
+mkdirSync(OUT, { recursive: true });
+
+const img = (k) => { if (!A[k]) throw new Error(`asset not uploaded: ${k}`); return A[k]; };
+
+// tokens (assets/ym-custom.css)
+const OLIVE = '#918450', ORANGE = '#F16022', PEACH = '#FFB563', RED = '#FF0000', RED_DK = '#cc0000';
+const DARK = '#1a1a1a', PAPER = '#ede4d3', INK = '#3B3229', CREAM = '#F0EEE2';
+const COND = "'Arial Narrow','Helvetica Neue',Helvetica,Arial,sans-serif";
+const BODY = "Arial,'Helvetica Neue',Helvetica,sans-serif";
+const SITE = 'https://yardmicrowaves.com';
+const IG = 'https://www.instagram.com/yardmicrowaves';
+const FB = 'https://www.facebook.com/yardmicrowaves';
+const TT = 'https://www.tiktok.com/@yardmicrowaves';
+
+// ------------------------------------------------------------ components ----
+const row = (inner, pad = '0 40px', extra = '') => `<tr><td align="center" class="ym-pad" style="padding:${pad};${extra}">${inner}</td></tr>`;
+
+function picture(k, { w, alt = '', href = null, style = '' } = {}) {
+  const a = img(k); const width = w || a.w;
+  let t = `<img src="${a.url}" width="${width}" alt="${alt}" style="display:block;width:${width}px;max-width:100%;height:auto;border:0;${style}"/>`;
+  if (href) t = `<a href="${href}" target="_blank" style="text-decoration:none;">${t}</a>`;
+  return t;
+}
+const headline = (k, alt) => row(picture(`h-${k}`, { alt, style: 'margin:0 auto;' }), '18px 30px 4px');
+const hero = (k = 'hero-smoker') => `<tr><td style="padding:0;line-height:0;font-size:0;">${picture(k, { w: 600, alt: 'Yard Microwaves' })}</td></tr>`;
+
+/** Red pill (theme .ym-btn-red): HTML pill + Milenia label image, alt degrades to text. */
+function button(k, href, alt) {
+  const a = img(`b-${k}`);
+  return `<table role="presentation" border="0" cellpadding="0" cellspacing="0" align="center" style="margin:10px auto 6px;"><tr>
+<td align="center" bgcolor="${RED}" style="border-radius:20px;padding:13px 36px 15px;">
+<a href="${href}" target="_blank" style="text-decoration:none;color:#ffffff;font-family:${BODY};font-size:18px;font-weight:bold;">
+<img src="${a.url}" width="${a.w}" alt="${alt}" style="display:block;width:${a.w}px;max-width:${a.w}px;height:auto;border:0;"/></a></td></tr></table>`;
+}
+const cta = (k, href, alt) => row(button(k, href, alt), '4px 40px 18px');
+
+const block = (html, style = '') => `<div class="klaviyo-block klaviyo-text-block" style="${style}">${html}</div>`;
+const lede = (html) => block(html, `font-family:${COND};font-size:16px;line-height:1.45;letter-spacing:.6px;text-transform:uppercase;color:${OLIVE};text-align:center;padding:2px 0 14px;`);
+const para = (html) => block(html, `font-family:${COND};font-size:17px;line-height:1.55;color:${INK};padding:0 0 12px;`);
+const small = (html) => block(html, `font-family:${COND};font-size:14px;line-height:1.5;color:${INK};padding:0 0 10px;`);
+/** Coupon callout — dashed olive ticket, Permanent-Marker-ish via condensed caps. */
+const coupon = (html) => block(`<table role="presentation" border="0" cellpadding="0" cellspacing="0" align="center" style="margin:6px auto 14px;"><tr><td align="center" style="border:2px dashed ${OLIVE};border-radius:8px;padding:12px 22px;font-family:${COND};font-size:16px;line-height:1.4;letter-spacing:.8px;text-transform:uppercase;color:${OLIVE};">${html}</td></tr></table>`, 'text-align:center;padding:0;');
+
+/** Editable body region (Klaviyo hybrid template). */
+const region = (blocks) => `<tr><td align="left" class="ym-pad" data-klaviyo-region="true" data-klaviyo-region-width-pixels="600" style="padding:10px 44px 4px;">${blocks.join('\n')}</td></tr>`;
+
+const showcase = () => row(picture('showcase', { w: 600, alt: 'Rub & Plug and Smoke Signal tees — relaxed fit, crew neck, heavy weight', href: SITE }), '6px 0 0');
+const quality = () => row(picture('quality-band', { w: 600, alt: 'Quality beyond compare. Preshrunk for perfection. Just like your brisket, our shirts exceed expectations. Guaranteed.' }), '4px 0 10px');
+const freeship = () => row(picture('freeship', { w: 150, alt: 'Free shipping on $50+', style: 'margin:0 auto;' }), '0 0 10px');
+const recipe = () => row(picture('recipe-card', { w: 600, alt: 'From our smoker to yours — secret ingredients in our shirts: relaxed fit, heavy weight 100% combed cotton, crew neck with ribbing, shoulder-to-shoulder tape, preshrunk, double needle hems' }), '6px 0 4px');
+const signoff = (text = 'The Yard Microwaves Team') => row(`<table role="presentation" border="0" cellpadding="0" cellspacing="0" align="center"><tr>
+<td valign="middle" style="padding-right:14px;">${picture('mascot', { w: 110, alt: '' })}</td>
+<td valign="middle" style="font-family:${COND};font-size:15px;line-height:1.4;letter-spacing:.6px;text-transform:uppercase;color:${OLIVE};">Sincerely,<br/><strong>${text}</strong></td></tr></table>`, '4px 40px 14px');
+
+/** Shopify line items (cart / order / shipping). priceExpr is a Klaviyo tag for the row price. */
+function lineItems({ priceExpr, imageExpr, titleExpr, subExpr = '' }) {
+  return `<table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%" style="border-collapse:collapse;">
+{% for item in event.extra.line_items %}
+<tr>
+<td width="96" valign="top" style="padding:8px 14px 8px 0;border-bottom:1px dashed ${OLIVE};">
+<a href="{{ organization.url|trim_slash }}/products/{{ item.product.handle }}" target="_blank" style="display:block;"><img src="${imageExpr}" width="96" alt="" style="display:block;width:96px;height:auto;border:0;border-radius:4px;"/></a></td>
+<td valign="middle" style="padding:8px 0;border-bottom:1px dashed ${OLIVE};font-family:${COND};font-size:16px;line-height:1.4;color:${INK};">
+<a href="{{ organization.url|trim_slash }}/products/{{ item.product.handle }}" target="_blank" style="color:${INK};text-decoration:none;font-weight:bold;">${titleExpr}</a>${subExpr ? `<br/><span style="color:${OLIVE};font-size:14px;">${subExpr}</span>` : ''}<br/><span style="color:${OLIVE};font-size:14px;letter-spacing:.5px;text-transform:uppercase;">Qty {{ item.quantity|floatformat:0 }}</span></td>
+<td width="80" align="right" valign="middle" style="padding:8px 0;border-bottom:1px dashed ${OLIVE};font-family:${COND};font-size:16px;color:${INK};white-space:nowrap;">${priceExpr}</td>
+</tr>
+{% endfor %}
+</table>`;
+}
+const IMG_EXPR = `{% if item.product.variant.images.0.src %}{{ item.product.variant.images.0.src }}{% else %}{{ item.product.images.0.src|missing_product_image }}{% endif %}`;
+const cartItems = () => row(`{% if event.extra.line_items %}${lineItems({ priceExpr: `{% currency_format item.line_price|floatformat:2 %}`, imageExpr: IMG_EXPR, titleExpr: '{{ item.product.title }}', subExpr: '{{ item.variant_title }}' })}{% endif %}`, '6px 44px 12px');
+const orderItems = () => row(`{% if event.extra.line_items %}${lineItems({ priceExpr: `{% currency_format item.price|floatformat:2 %}`, imageExpr: IMG_EXPR, titleExpr: '{{ item.product.title }}', subExpr: '{{ item.variant_title }}' })}{% endif %}`, '6px 44px 4px');
+const shipItems = () => row(`{% if event.extra.line_items %}${lineItems({ priceExpr: `{% currency_format item.price|floatformat:2 %}`, imageExpr: IMG_EXPR, titleExpr: '{{ item.name }}' })}{% endif %}`, '6px 44px 12px');
+
+const totals = () => row(`<table role="presentation" border="0" cellpadding="0" cellspacing="0" align="right" style="font-family:${COND};font-size:16px;line-height:1.7;color:${INK};">
+<tr><td style="padding-right:18px;color:${OLIVE};text-transform:uppercase;letter-spacing:.5px;">Subtotal</td><td align="right">{{ event.extra.subtotal_price }}</td></tr>
+<tr><td style="padding-right:18px;color:${OLIVE};text-transform:uppercase;letter-spacing:.5px;">Shipping</td><td align="right">{{ event.extra.shipping_lines.0.price }}</td></tr>
+<tr><td style="padding-right:18px;color:${OLIVE};text-transform:uppercase;letter-spacing:.5px;font-weight:bold;">Total</td><td align="right" style="font-weight:bold;">{{ event|lookup:'$value' }}</td></tr>
+</table>`, '0 44px 12px');
+
+const addressBlock = (label, p) => `<div style="font-family:${COND};font-size:14px;line-height:1.5;color:${INK};"><div style="color:${OLIVE};text-transform:uppercase;letter-spacing:.6px;font-size:13px;padding-bottom:3px;">${label}</div>
+{{ event.extra.${p}.name|title }}<br/>{{ event.extra.${p}.address1 }}{% if event.extra.${p}.address2 %}, {{ event.extra.${p}.address2 }}{% endif %}<br/>{{ event.extra.${p}.city|title }}, {{ event.extra.${p}.province_code }} {{ event.extra.${p}.zip }}<br/>{{ event.extra.${p}.country }}</div>`;
+const addresses = () => row(`<table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%"><tr>
+<td width="50%" valign="top" style="padding:8px 10px 8px 0;">${addressBlock('Billing address', 'billing_address')}</td>
+<td width="50%" valign="top" style="padding:8px 0 8px 10px;">${addressBlock('Shipping address', 'shipping_address')}</td></tr></table>`, '0 44px 10px');
+
+/** Viewed / reviewed product card. */
+const productCard = ({ imgExpr, titleExpr, subExpr, href }) => row(`<table role="presentation" border="0" cellpadding="0" cellspacing="0" align="center" style="margin:0 auto;"><tr>
+<td align="center" style="padding:0 0 8px;"><a href="${href}" target="_blank" style="display:block;"><img src="${imgExpr}" width="240" alt="${titleExpr}" style="display:block;width:240px;max-width:100%;height:auto;border:0;border-radius:6px;"/></a></td></tr>
+<tr><td align="center" style="font-family:${COND};font-size:19px;line-height:1.3;color:${INK};font-weight:bold;"><a href="${href}" target="_blank" style="color:${INK};text-decoration:none;">${titleExpr}</a></td></tr>
+${subExpr ? `<tr><td align="center" style="font-family:${COND};font-size:15px;line-height:1.4;letter-spacing:.5px;text-transform:uppercase;color:${OLIVE};">${subExpr}</td></tr>` : ''}
+</table>`, '6px 40px 10px');
+
+/** 1–5 star rating row (each star links with ?rating=n). */
+const stars = () => row(`<div style="font-family:${COND};font-size:17px;line-height:1.4;color:${INK};padding-bottom:8px;">How would you rate this item?</div>
+<table role="presentation" border="0" cellpadding="0" cellspacing="0" align="center"><tr>${[1, 2, 3, 4, 5].map((n) =>
+  `<td style="padding:0 4px;"><a href="{{ event.review_link }}?rating=${n}" target="_blank" style="display:block;">${picture('star', { w: 36, alt: `Rate it ${n} star${n > 1 ? 's' : ''}` })}</a></td>`).join('')}</tr></table>`, '4px 40px 16px');
+
+/** 3-up "trending" grid from Klaviyo's Shopify product feed. */
+const feedGrid = (title) => row(`<div style="font-family:${COND};font-size:15px;line-height:1.4;letter-spacing:.8px;text-transform:uppercase;color:${OLIVE};padding:0 0 12px;text-align:center;">${title}</div>
+<table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%"><tr>${[0, 1, 2].map((i) => `
+<td width="33%" valign="top" align="center" style="padding:0 6px;">{% if feeds.SHOP_POPULAR_ALL_CATEGORIES|index:${i} %}{% with item=feeds.SHOP_POPULAR_ALL_CATEGORIES|index:${i} %}
+<a href="{{ item.url }}" target="_blank" style="display:block;text-decoration:none;"><img src="{{ item.image_full_url }}" width="160" alt="{{ item.title|safe }}" style="display:block;width:160px;max-width:100%;height:auto;border:0;border-radius:6px;margin:0 auto 8px;"/>
+<div style="font-family:${COND};font-size:14px;line-height:1.3;color:${INK};font-weight:bold;">{{ item.title|safe }}</div>
+<div style="font-family:${COND};font-size:14px;line-height:1.5;color:${OLIVE};">{{ item.price|default:'' }}</div></a>
+{% endwith %}{% endif %}</td>`).join('')}</tr></table>`, '8px 30px 14px');
+
+/** Dark HOT LINKS footer, torn paper edge on top — the theme's ym-footer-cta. */
+function footer() {
+  const hl = (k, href, alt) => `<td align="center" width="33%" style="padding:0;"><a href="${href}" target="_blank" style="display:block;">${picture(`hotlink-${k}`, { w: 196, alt, style: 'margin:0 auto;' })}</a></td>`;
+  return `<tr><td style="padding:0;line-height:0;font-size:0;" bgcolor="${PAPER}">${picture('torn-to-dark', { w: 600, alt: '' })}</td></tr>
+<tr><td align="center" bgcolor="${DARK}" style="background-color:${DARK};padding:10px 20px 32px;">
+${picture('hotlinks-heading', { alt: 'Hot links', style: 'margin:0 auto 2px;' })}
+<table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width:588px;"><tr>${hl('instagram', IG, 'Instagram')}${hl('facebook', FB, 'Facebook')}${hl('tiktok', TT, 'TikTok')}</tr></table>
+<div style="padding:18px 0 12px;">${picture('logo-white', { w: 132, alt: 'Yard Microwaves', href: SITE, style: 'margin:0 auto;' })}</div>
+<div style="font-family:${COND};font-size:14px;line-height:1.5;letter-spacing:1px;text-transform:uppercase;color:${CREAM};padding-bottom:12px;">Smoking meats. Chugging pilsners.<br/>Bringing families together.</div>
+<div style="font-family:${BODY};font-size:12px;line-height:1.75;color:#CBBFA2;">
+<a href="${IG}" target="_blank" style="color:${PEACH};text-decoration:none;font-weight:bold;">@yardmicrowaves</a>&nbsp;&bull;&nbsp;<a href="${SITE}" target="_blank" style="color:${PEACH};text-decoration:none;font-weight:bold;">yardmicrowaves.com</a><br/>
+Yard Microwaves &middot; 24002 Via Fabricante #225, Mission Viejo, CA 92691<br/>
+You're getting this because you signed up at the Yard.<br/>
+<span style="color:${PEACH};">{% unsubscribe 'Unsubscribe' %}</span>
+</div></td></tr>`;
+}
+
+function header() {
+  return `<tr><td class="ym-pad" style="padding:22px 20px 6px;"><table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%"><tr>
+<td align="center" width="33%" class="ym-nav">${picture('nav-shop', { alt: 'The Shop', href: SITE, style: 'margin:0 auto;' })}</td>
+<td align="center" width="34%" class="ym-logo">${picture('badge-logo', { w: 176, alt: 'Yard Microwaves', href: SITE, style: 'margin:0 auto;' })}</td>
+<td align="center" width="33%" class="ym-nav">${picture('nav-story', { alt: 'Our Story', href: `${SITE}/pages/our-story`, style: 'margin:0 auto;' })}</td>
+</tr></table></td></tr>`;
+}
+
+function page(rows) {
+  const paper = img('paper-bg').url;
+  return `<html>
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title></title>
+<style>
+body { margin:0; padding:0; background-color:${PAPER}; -webkit-text-size-adjust:100%; }
+img { border:0; line-height:100%; max-width:100%; }
+a { color:${RED_DK}; }
+p { margin:0 0 10px; }
+ul { margin:0 0 10px; padding-left:22px; }
+li { margin:0 0 4px; }
+h3, h4 { font-family:${COND}; color:${OLIVE}; text-transform:uppercase; letter-spacing:.6px; font-size:17px; line-height:1.3; margin:4px 0 8px; }
+table { border-collapse:collapse; }
+@media only screen and (max-width:620px) {
+  .ym-container { width:100% !important; }
+  .ym-pad { padding-left:16px !important; padding-right:16px !important; }
+  .ym-nav img { width:66px !important; }
+  .ym-logo img { width:140px !important; }
+}
+</style>
+</head>
+<body style="margin:0;padding:0;background-color:${PAPER};">
+<table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%" bgcolor="${PAPER}" background="${paper}" style="background-color:${PAPER};background-image:url('${paper}');background-size:cover;background-position:center top;">
+<tr><td align="center" style="padding:0;">
+<table role="presentation" border="0" cellpadding="0" cellspacing="0" width="600" class="ym-container" style="width:600px;max-width:600px;">
+${header()}
+${rows.join('\n')}
+${footer()}
+</table>
+</td></tr>
+</table>
+</body>
+</html>`;
+}
+
+// ------------------------------------------------------------- templates ----
+const FIRST = `{{ first_name|title|default:'there' }}`;
+const INSIDER_LIST = `<ul><li>Exciting product announcements</li><li>Exclusive deals and promotions</li><li>Content and recommendations we'll customize just for you!</li></ul>`;
+
+const TEMPLATES = {
+  'welcome-1-new': {
+    name: 'Welcome #1 - New Subscriber (20% Off)',
+    rows: [
+      hero(),
+      headline('welcome-new', 'Welcome to the Yard Microwaves family!'),
+      region([
+        lede(`Hey ${FIRST}, we're glad you're here!`),
+        para(`<p>So, what can you expect now that you're an insider?</p>${INSIDER_LIST}<p style="margin:0;">We save the very best for those that want to stay in the know.</p>`),
+        coupon(`&#11088; Use code <strong>INSERT-COUPON</strong> for 20% off your first purchase! &#11088;`),
+      ]),
+      cta('shop-now', '{{ organization.url }}', 'Shop Now'),
+      showcase(),
+      feedGrid('Trending items hand-picked just for you'),
+      quality(),
+    ],
+  },
+  'welcome-1-existing': {
+    name: 'Welcome #1 - Existing Customer',
+    rows: [
+      hero(),
+      headline('welcome-exist', "Awesome! You're in!"),
+      region([
+        lede(`Hi, ${FIRST}!`),
+        para(`<p>What can you expect from {{ organization.name }} now that you're a real insider?</p><ul><li><strong>Exciting product announcements</strong></li><li><strong>Exclusive deals and promotions</strong></li><li><strong>Content and recommendations we'll customize just for you!</strong></li></ul><p style="margin:0;">Needless to say, we save the very best for those that want to stay in the know. And we're glad you're here!</p>`),
+      ]),
+      signoff(),
+      cta('shop-now', '{{ organization.url }}', 'Shop Now'),
+      showcase(),
+      quality(),
+    ],
+  },
+  'welcome-2-follow': {
+    name: 'Welcome #2 - Follow Us',
+    rows: [
+      headline('follow', 'Follow the smoke'),
+      region([
+        lede(`Hey ${FIRST},`),
+        para(`<p style="margin:0;">Email is where we make it official. Instagram is where we misbehave &mdash; new designs, drop previews, and an unreasonable amount of brisket footage.</p>`),
+      ]),
+      cta('follow-ig', IG, 'Follow @yardmicrowaves'),
+      row(picture('story-collage', { w: 320, alt: 'Backyard pit shots from the Yard', href: IG, style: 'margin:0 auto;' }), '4px 40px 10px'),
+      row(picture('pellets', { w: 90, alt: '', style: 'margin:0 auto;' }), '0 0 8px'),
+      quality(),
+    ],
+  },
+  'review-request': {
+    name: 'Review Request',
+    rows: [
+      headline('review-req', 'What did you think?'),
+      region([
+        lede(`Hi {{ first_name|default:"there" }},`),
+        para(`<p style="margin:0;">Thank you for shopping with us. We'd love to hear what you think of your latest purchase.</p>`),
+      ]),
+      productCard({ imgExpr: '{{ event.structured_product.image_url }}', titleExpr: '{{ event.product.title }}', subExpr: '{{ event.structured_product.variant_name }}', href: '{{ event.review_link }}' }),
+      stars(),
+      cta('leave-review', '{{ event.review_link }}', 'Leave a review'),
+      region([small(`<p style="margin:0;text-align:center;">We appreciate your feedback.<br/>{{ organization.name }}</p>`)]),
+      signoff(),
+    ],
+  },
+  'review-reminder': {
+    name: 'Review Reminder',
+    rows: [
+      headline('review-rem', "We'd love to hear from you"),
+      region([lede(`Tell us what you think about your latest purchase.`)]),
+      productCard({ imgExpr: '{{ event.structured_product.image_url }}', titleExpr: '{{ event.product.title }}', subExpr: '{{ event.structured_product.variant_name }}', href: '{{ event.review_link }}' }),
+      stars(),
+      cta('leave-review', '{{ event.review_link }}', 'Leave a review'),
+      region([small(`<p style="margin:0;text-align:center;">We appreciate your feedback.<br/>{{ organization.name }}</p>`)]),
+      signoff(),
+    ],
+  },
+  'shipping-confirmation': {
+    name: 'Shipping Confirmation',
+    rows: [
+      headline('shipping', "It's on the way!"),
+      region([
+        lede(`Hi {{ event.extra.customer.default_address.first_name|default:'there' }},`),
+        para(`<p style="margin:0;">We've got some good news! All of the items from order <strong>{{ event.extra.order_number }}</strong> have now been shipped:</p>`),
+      ]),
+      shipItems(),
+      region([
+        para(`<p>They are being shipped {% if event.extra.fulfillments.0.tracking_company %}via {{ event.extra.fulfillments.0.tracking_company }} {% endif %}to the following address:</p><p>{{ event.extra.shipping_address.first_name }} {{ event.extra.shipping_address.last_name }}<br/>{{ event.extra.shipping_address.address1 }}<br/>{{ event.extra.shipping_address.city }}, {{ event.extra.shipping_address.province_code }} {{ event.extra.shipping_address.zip }}</p><p style="margin:0;">The tracking number for these items is <strong>{{ event.extra.fulfillments.0.tracking_number }}</strong>. Use the link below to see the status of your shipment.</p>`),
+      ]),
+      cta('track-package', '{{ event.extra.fulfillments.0.tracking_url }}', 'Track Your Package'),
+      region([
+        small(`<p>Please allow some time for the status of the shipment to correctly display at the above address.</p><p style="margin:0;">You will receive a confirmation email when more items from your order have been shipped.</p>`),
+        para(`<p style="margin:0;">Thanks again for ordering from {{ event.extra.fulfillments.0.line_items.0.vendor|default:'Yard Microwaves' }}!</p>`),
+      ]),
+      signoff(),
+      recipe(),
+    ],
+  },
+  'order-confirmation': {
+    name: 'Order Confirmation',
+    rows: [
+      headline('order', 'Thank you for your order!'),
+      region([
+        lede(`Order <strong>{{ event.extra.order_number }}</strong> is in.`),
+        para(`<p style="margin:0;">This email is to confirm your order. We'll send another note the moment it ships.</p>`),
+      ]),
+      region([block(`<h4 style="margin:0;">Order details</h4>`)]),
+      orderItems(),
+      totals(),
+      addresses(),
+      cta('track-order', `{{ event.extra.order_status_url|default:organization.url }}`, 'Track Your Order!'),
+      signoff(),
+      recipe(),
+    ],
+  },
+  'abandoned-cart-1': {
+    name: 'Abandoned Cart #1',
+    rows: [
+      headline('cart-1', "Don't let your items slip away!"),
+      region([lede(`Your cart is saved, but these items won't last forever &mdash; come back and complete your order today!`)]),
+      cartItems(),
+      cta('back-to-cart', '{{ event.extra.checkout_url }}', 'Back to my cart'),
+      freeship(),
+      feedGrid('Most loved at the Yard'),
+      quality(),
+    ],
+  },
+  'abandoned-cart-2': {
+    name: 'Abandoned Cart #2',
+    rows: [
+      headline('cart-2', 'Finish your order before your items sell out'),
+      region([lede(`We saved all of the great items you've added to your cart, so when you're ready to buy, simply complete your purchase.`)]),
+      cartItems(),
+      cta('back-to-cart', '{{ event.extra.checkout_url }}', 'Back to my cart'),
+      freeship(),
+      feedGrid('Top best sellers'),
+      quality(),
+    ],
+  },
+  'abandoned-cart-3': {
+    name: 'Abandoned Cart #3 (15% Off)',
+    rows: [
+      headline('cart-2', 'Finish your order before your items sell out'),
+      region([
+        lede(`We saved all of the great items you've added to your cart, so when you're ready to buy, simply complete your purchase.`),
+        coupon(`Use code <strong>INSERT-COUPON</strong> for 15% off &mdash; good for the next 48 hours.`),
+      ]),
+      cartItems(),
+      cta('back-to-cart', '{{ event.extra.checkout_url }}', 'Back to my cart'),
+      freeship(),
+      feedGrid('Top best sellers'),
+      quality(),
+    ],
+  },
+  'browse-abandonment-1': {
+    name: 'Browse Abandonment #1',
+    rows: [
+      headline('browse', 'Well, what are you waiting for?'),
+      region([
+        lede(`Hey ${FIRST},`),
+        para(`<p style="margin:0;">This item is going fast, so grab it while you still can!</p>`),
+      ]),
+      productCard({ imgExpr: '{{ event.ImageURL }}', titleExpr: '{{ event.Name }}', subExpr: '{{ event.Price|striptags }}', href: '{{ event.URL }}' }),
+      cta('shop-now', '{{ organization.url }}', 'Shop Now'),
+      feedGrid('You might also like'),
+      quality(),
+    ],
+  },
+  'browse-abandonment-2': {
+    name: 'Browse Abandonment #2',
+    rows: [
+      headline('browse', 'Well, what are you waiting for?'),
+      region([
+        lede(`Hey ${FIRST},`),
+        para(`<p style="margin:0;">This item is going fast, so grab it while you still can!</p>`),
+      ]),
+      productCard({ imgExpr: '{{ event.ImageURL }}', titleExpr: '{{ event.Name }}', subExpr: '{{ event.Price|striptags }}', href: '{{ event.URL }}' }),
+      cta('shop-now', '{{ organization.url }}', 'Shop Now'),
+      showcase(),
+      quality(),
+    ],
+  },
+};
+
+// ------------------------------------------------------------------ build ----
+const strip = (h) => h.replace(/<style[\s\S]*?<\/style>/g, '').replace(/<[^>]+>/g, ' ').replace(/&nbsp;|&mdash;|&bull;|&middot;|&#11088;/g, ' ').replace(/\s+/g, ' ').trim();
+const index = {};
+for (const [slug, t] of Object.entries(TEMPLATES)) {
+  const html = page(t.rows);
+  writeFileSync(resolve(OUT, `${slug}.html`), html);
+  index[slug] = { name: t.name, text: `Yard Microwaves\n\n${strip(html).slice(0, 1200)}\n\n{% unsubscribe 'Unsubscribe' %}` };
+  console.log(`  ${slug.padEnd(24)} ${(html.length / 1024).toFixed(1)}KB`);
+}
+writeFileSync(resolve(OUT, 'index.json'), JSON.stringify(index, null, 1));
+console.log(`build: ${Object.keys(index).length} templates → build/templates`);

--- a/email/klaviyo.mjs
+++ b/email/klaviyo.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+/**
+ * Klaviyo side of the pipeline. Needs KLAVIYO_YM_API_KEY (private key with
+ * images:write + templates:write) in the environment.
+ *
+ *   node klaviyo.mjs upload   # build/assets/* → Klaviyo image library → assets.json
+ *   node klaviyo.mjs push     # build/templates/*.html → create/update templates → templates.json
+ *   node klaviyo.mjs render   # render each pushed template with sample data → build/rendered/*.html
+ *
+ * Images are sent as base64 data URIs straight from disk (no third-party
+ * host). Klaviyo has no image delete endpoint, so uploads are de-duplicated by
+ * content hash: an unchanged file is never re-uploaded.
+ */
+import { readFileSync, writeFileSync, readdirSync, existsSync, mkdirSync } from 'node:fs';
+import { resolve, dirname, basename, extname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createHash } from 'node:crypto';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const KEY = process.env.KLAVIYO_YM_API_KEY;
+if (!KEY) { console.error('KLAVIYO_YM_API_KEY is not set'); process.exit(2); }
+const API = 'https://a.klaviyo.com/api';
+const REV = '2025-07-15';
+const PREFIX = 'YM Theme - ';          // template names; the older Figma-based set is "YM - …"
+const ASSETS_JSON = resolve(HERE, 'assets.json');
+const TEMPLATES_JSON = resolve(HERE, 'templates.json');
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+async function api(method, path, body, attempt = 0) {
+  const res = await fetch(`${API}${path}`, {
+    method,
+    headers: { Authorization: `Klaviyo-API-Key ${KEY}`, revision: REV, 'content-type': 'application/vnd.api+json', accept: 'application/vnd.api+json' },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (res.status === 429 && attempt < 5) { await sleep(1500 * (attempt + 1)); return api(method, path, body, attempt + 1); }
+  const text = await res.text();
+  let json; try { json = text ? JSON.parse(text) : {}; } catch { json = { raw: text }; }
+  if (!res.ok) throw new Error(`${method} ${path} → ${res.status}: ${JSON.stringify(json.errors || json).slice(0, 600)}`);
+  return json;
+}
+const loadJson = (f, d = {}) => (existsSync(f) ? JSON.parse(readFileSync(f, 'utf8')) : d);
+const sha = (buf) => createHash('sha1').update(buf).digest('hex').slice(0, 12);
+
+// ---------------------------------------------------------------- upload ----
+async function upload() {
+  const dir = resolve(HERE, 'build', 'assets');
+  const manifest = loadJson(resolve(dir, 'manifest.json'));
+  const assets = loadJson(ASSETS_JSON);
+  let uploaded = 0, skipped = 0;
+  for (const [key, meta] of Object.entries(manifest)) {
+    const buf = readFileSync(resolve(dir, meta.file));
+    const hash = sha(buf);
+    if (assets[key]?.hash === hash && assets[key]?.url) { skipped++; continue; }
+    const mime = extname(meta.file) === '.jpg' ? 'image/jpeg' : 'image/png';
+    const body = { data: { type: 'image', attributes: { name: `ym-email-${key}-${hash}`, import_from_url: `data:${mime};base64,${buf.toString('base64')}`, hidden: false } } };
+    const r = await api('POST', '/images/', body);
+    assets[key] = { url: r.data.attributes.image_url, id: r.data.id, hash, w: meta.w, h: meta.h, file: meta.file };
+    uploaded++;
+    console.log(`  ↑ ${key.padEnd(20)} ${(buf.length / 1024).toFixed(0).padStart(4)}KB  ${r.data.attributes.image_url}`);
+    await sleep(350);
+  }
+  writeFileSync(ASSETS_JSON, JSON.stringify(assets, null, 1));
+  console.log(`upload: ${uploaded} new, ${skipped} unchanged → assets.json`);
+}
+
+// ------------------------------------------------------------------ push ----
+async function push() {
+  const dir = resolve(HERE, 'build', 'templates');
+  const index = loadJson(resolve(dir, 'index.json'));  // slug → {name, text}
+  const state = loadJson(TEMPLATES_JSON);
+  for (const [slug, meta] of Object.entries(index)) {
+    const html = readFileSync(resolve(dir, `${slug}.html`), 'utf8');
+    const name = PREFIX + meta.name;
+    const attributes = { name, editor_type: 'USER_DRAGGABLE', html, text: meta.text || '' };
+    const hash = sha(Buffer.from(html + name));
+    if (state[slug]?.id) {
+      if (state[slug].hash === hash) { console.log(`  = ${slug} unchanged (${state[slug].id})`); continue; }
+      await api('PATCH', `/templates/${state[slug].id}/`, { data: { type: 'template', id: state[slug].id, attributes: { name, html, text: meta.text || '' } } });
+      state[slug] = { ...state[slug], name, hash };
+      console.log(`  ~ ${slug} updated  https://www.klaviyo.com/email-editor/${state[slug].id}/edit`);
+    } else {
+      const r = await api('POST', '/templates/', { data: { type: 'template', attributes } });
+      state[slug] = { id: r.data.id, name, hash };
+      console.log(`  + ${slug} created  https://www.klaviyo.com/email-editor/${r.data.id}/edit`);
+    }
+    await sleep(400);
+  }
+  writeFileSync(TEMPLATES_JSON, JSON.stringify(state, null, 1));
+  console.log(`push: ${Object.keys(state).length} templates → templates.json`);
+}
+
+// ---------------------------------------------------------------- render ----
+// Sample context so dynamic blocks (cart items, order, review product) show up.
+const SAMPLE = {
+  first_name: 'Rich',
+  organization: { name: 'Yard Microwaves', url: 'https://yardmicrowaves.com' },
+  event: {
+    extra: {
+      order_number: '#1042',
+      checkout_url: 'https://yardmicrowaves.com/cart',
+      subtotal_price: '$58.00', total_price: '$63.95',
+      shipping_lines: [{ price: '$5.95' }],
+      customer: { default_address: { first_name: 'Rich' } },
+      billing_address: { name: 'Rich Ornelas', address1: '24002 Via Fabricante #225', city: 'Mission Viejo', province: 'CA', province_code: 'CA', zip: '92691', country: 'United States', first_name: 'Rich', last_name: 'Ornelas' },
+      shipping_address: { name: 'Rich Ornelas', address1: '24002 Via Fabricante #225', city: 'Mission Viejo', province: 'CA', province_code: 'CA', zip: '92691', country: 'United States', first_name: 'Rich', last_name: 'Ornelas' },
+      fulfillments: [{ tracking_company: 'USPS', tracking_number: '9400 1000 0000 0000 0000 00', tracking_url: 'https://tools.usps.com', line_items: [{ vendor: 'Yard Microwaves' }] }],
+      line_items: [
+        { name: 'Rub & Plug Tee - Bone / L', title: 'Rub & Plug Tee', quantity: 1, price: '29.00', line_price: '29.00', product: { title: 'Rub & Plug Tee', handle: 'rub-plug-t-shirt', images: [{ src: 'https://yardmicrowaves.com/cdn/shop/files/rubplug-front.png' }], variant: { title: 'Bone / L', images: [] } }, variant_title: 'Bone / L' },
+        { name: 'Smoke Signal Tee - Briquette / M', title: 'Smoke Signal Tee', quantity: 1, price: '29.00', line_price: '29.00', product: { title: 'Smoke Signal Tee', handle: 'smoke-signals', images: [{ src: 'https://yardmicrowaves.com/cdn/shop/files/smokesig-front.png' }], variant: { title: 'Briquette / M', images: [] } }, variant_title: 'Briquette / M' },
+      ],
+    },
+    ImageURL: 'https://yardmicrowaves.com/cdn/shop/files/rubplug-front.png', Name: 'Rub & Plug Tee', Price: '$29.00', URL: 'https://yardmicrowaves.com/products/rub-plug-t-shirt',
+    product: { title: 'Rub & Plug Tee' },
+    structured_product: { title: 'Rub & Plug Tee', image_url: 'https://yardmicrowaves.com/cdn/shop/files/rubplug-front.png', variant_name: 'Bone / L' },
+    review_link: 'https://yardmicrowaves.com/reviews/new',
+  },
+};
+async function render() {
+  const state = loadJson(TEMPLATES_JSON);
+  const out = resolve(HERE, 'build', 'rendered');
+  mkdirSync(out, { recursive: true });
+  for (const [slug, t] of Object.entries(state)) {
+    const r = await api('POST', '/template-render/', { data: { type: 'template', id: t.id, attributes: { context: SAMPLE } } });
+    writeFileSync(resolve(out, `${slug}.html`), r.data.attributes.html);
+    console.log(`  rendered ${slug}`);
+    await sleep(1100); // 60/min steady
+  }
+}
+
+const cmd = process.argv[2];
+({ upload, push, render }[cmd] || (() => { console.error('usage: klaviyo.mjs upload|push|render'); process.exit(2); }))()
+  .catch((e) => { console.error(e.message || e); process.exit(1); });

--- a/email/package-lock.json
+++ b/email/package-lock.json
@@ -1,0 +1,60 @@
+{
+  "name": "ym-email-templates",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ym-email-templates",
+      "devDependencies": {
+        "playwright": "1.61.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/email/package.json
+++ b/email/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "ym-email-templates",
+  "private": true,
+  "type": "module",
+  "description": "Klaviyo email templates for Yard Microwaves, built from the theme's own assets and fonts.",
+  "scripts": {
+    "assets": "node render-assets.mjs",
+    "upload": "node klaviyo.mjs upload",
+    "build": "node build.mjs",
+    "preview": "node preview.mjs",
+    "push": "node klaviyo.mjs push",
+    "all": "npm run assets && npm run upload && npm run build && npm run preview && npm run push"
+  },
+  "devDependencies": {
+    "playwright": "1.61.1"
+  }
+}

--- a/email/preview.mjs
+++ b/email/preview.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+/**
+ * Screenshot the Klaviyo-rendered templates (build/rendered/*.html, from
+ * `klaviyo.mjs render`) at desktop (640) and mobile (390) widths, plus one
+ * contact sheet of every email → build/previews/.
+ */
+import { chromium } from 'playwright';
+import { readdirSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { resolve, dirname, basename } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const IN = resolve(HERE, 'build', 'rendered');
+const OUT = resolve(HERE, 'build', 'previews');
+mkdirSync(OUT, { recursive: true });
+
+const browser = await chromium.launch();
+const files = readdirSync(IN).filter((f) => f.endsWith('.html')).sort();
+const shots = [];
+for (const f of files) {
+  const slug = basename(f, '.html');
+  for (const [tag, width] of [['desktop', 640], ['mobile', 390]]) {
+    const page = await browser.newPage({ viewport: { width, height: 900 }, deviceScaleFactor: tag === 'mobile' ? 2 : 1 });
+    await page.goto(pathToFileURL(resolve(IN, f)).href, { waitUntil: 'networkidle' });
+    await page.waitForTimeout(300);
+    const out = resolve(OUT, `${slug}-${tag}.png`);
+    await page.screenshot({ path: out, fullPage: true });
+    const h = await page.evaluate(() => document.documentElement.scrollHeight);
+    console.log(`  ${slug}-${tag}  ${width}x${h}`);
+    if (tag === 'desktop') shots.push({ slug, file: `${slug}-desktop.png`, h });
+    await page.close();
+  }
+}
+// contact sheet: all desktop renders side by side, scaled to 300px wide
+const sheet = `<body style="margin:0;background:#333;padding:12px;font:12px monospace;color:#ddd;white-space:nowrap;">${shots.map((s) =>
+  `<div style="display:inline-block;vertical-align:top;margin:0 8px 8px 0;width:300px;white-space:normal;"><div style="padding:4px 0;">${s.slug}</div><img src="${s.file}" style="width:300px;display:block;"></div>`).join('')}</body>`;
+writeFileSync(resolve(OUT, '_sheet.html'), sheet);
+const page = await browser.newPage({ viewport: { width: Math.min(shots.length, 6) * 316 + 24, height: 800 } });
+await page.goto(pathToFileURL(resolve(OUT, '_sheet.html')).href, { waitUntil: 'networkidle' });
+await page.screenshot({ path: resolve(OUT, 'contact-sheet.png'), fullPage: true });
+await browser.close();
+console.log(`preview: ${files.length} templates → build/previews (contact-sheet.png)`);

--- a/email/render-assets.mjs
+++ b/email/render-assets.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+/**
+ * Render email-ready image assets from the theme's own files.
+ *
+ * Everything here is derived from ../assets (the Shopify theme): the badge
+ * logo, the three brand fonts (Milenia / Bananas VF / Permanent Marker), the
+ * butcher paper, torn edges, shirt mockups, mascot, sparkles, hot-links chain.
+ * Email clients can't load web fonts, so headline / nav / button type is
+ * rendered to PNG with the real fonts at 2x and served as images (with alt
+ * text). Output: build/assets/*.png|jpg + build/assets/manifest.json.
+ */
+import { chromium } from 'playwright';
+import { readFileSync, writeFileSync, mkdirSync, existsSync, copyFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const THEME_ASSETS = resolve(HERE, '..', 'assets');
+const OUT = resolve(HERE, 'build', 'assets');
+const TMP = resolve(HERE, 'build', 'tmp');
+mkdirSync(OUT, { recursive: true });
+mkdirSync(TMP, { recursive: true });
+
+// Theme tokens (assets/ym-custom.css :root)
+export const C = {
+  olive: '#918450', red: '#FF0000', redDark: '#cc0000', orange: '#F16022',
+  peach: '#FFB563', cream: '#F0EEE2', dark: '#1a1a1a', darkSoft: '#2c2c2c',
+  paper: '#ede4d3',
+};
+
+const b64 = (f) => readFileSync(resolve(THEME_ASSETS, f)).toString('base64');
+const FONT_CSS = `
+@font-face{font-family:'Milenia';src:url(data:font/woff2;base64,${b64('milenia.woff2')}) format('woff2');}
+@font-face{font-family:'Bananas';src:url(data:font/woff2;base64,${b64('bananas-vf-regular.woff2')}) format('woff2');font-weight:100 900;}
+@font-face{font-family:'BananasExp';src:url(data:font/woff2;base64,${b64('bananas-vf-bold-expanded.woff2')}) format('woff2');font-weight:100 900;}
+@font-face{font-family:'Marker';src:url(data:font/woff2;base64,${b64('permanent-marker.woff2')}) format('woff2');}
+`;
+const asset = (f) => pathToFileURL(resolve(THEME_ASSETS, f)).href;
+const logoSvg = readFileSync(resolve(THEME_ASSETS, 'ym-logo.svg'), 'utf8')
+  .replace(/width="125" height="64"/, 'width="100%" height="auto"');
+
+const manifest = {};
+let browser, page;
+
+/** Render `inner` inside a box of width w (height auto unless h) and screenshot it. */
+async function shot(name, inner, css = '', { w = 600, h = null, jpg = false, quality = 82, scale = 2, bg = 'transparent' } = {}) {
+  const html = `<!doctype html><html><head><meta charset="utf-8"><style>
+${FONT_CSS}
+html,body{margin:0;padding:0;background:${bg};}
+#s{position:relative;width:${w}px;${h ? `height:${h}px;` : ''}overflow:hidden;}
+${css}
+</style></head><body><div id="s">${inner}</div></body></html>`;
+  const f = resolve(TMP, `${name}.html`);
+  writeFileSync(f, html);
+  await page.setViewportSize({ width: Math.max(w + 40, 320), height: Math.max((h || 400) + 40, 200) });
+  await page.goto(pathToFileURL(f).href);
+  await page.evaluate(() => document.fonts.ready);
+  await page.waitForTimeout(80);
+  const el = page.locator('#s');
+  const box = await el.boundingBox();
+  const file = resolve(OUT, `${name}.${jpg ? 'jpg' : 'png'}`);
+  await el.screenshot({ path: file, omitBackground: !jpg, type: jpg ? 'jpeg' : 'png', quality: jpg ? quality : undefined, scale: 'css' });
+  manifest[name] = { file: `${name}.${jpg ? 'jpg' : 'png'}`, w: Math.round(box.width), h: Math.round(box.height) };
+  process.stdout.write(`  ${name.padEnd(22)} ${Math.round(box.width)}x${Math.round(box.height)}\n`);
+}
+
+/** Measure-then-render: type that should be exactly as wide as its content. */
+async function typeShot(name, inner, css, { maxW = 560, jpg = false } = {}) {
+  // render at maxW, measure the inner content, re-render tight
+  const probe = `<!doctype html><html><head><meta charset="utf-8"><style>${FONT_CSS}html,body{margin:0}#m{display:inline-block;max-width:${maxW}px}${css}</style></head><body><div id="m">${inner}</div></body></html>`;
+  const f = resolve(TMP, `${name}-probe.html`);
+  writeFileSync(f, probe);
+  await page.setViewportSize({ width: maxW + 40, height: 600 });
+  await page.goto(pathToFileURL(f).href);
+  await page.evaluate(() => document.fonts.ready);
+  const box = await page.locator('#m').boundingBox();
+  const w = Math.ceil(box.width) + 2;
+  return shot(name, `<div style="display:inline-block;width:${w}px">${inner}</div>`, css, { w, jpg });
+}
+
+const HEADLINES = {
+  'welcome-new':    'Welcome to the family!',
+  'welcome-exist':  "Awesome! You're in!",
+  'follow':         'Follow the smoke',
+  'review-req':     'What did you think?',
+  'review-rem':     "We'd love to hear from you",
+  'shipping':       "It's on the way!",
+  'order':          'Thank you for your order!',
+  'cart-1':         "Don't let your items slip away!",
+  'cart-2':         'Finish your order before it sells out',
+  'browse':         'Well, what are you waiting for?',
+};
+const BUTTONS = {
+  'shop-now': 'Shop Now',
+  'back-to-cart': 'Back to my cart',
+  'track-package': 'Track Your Package',
+  'track-order': 'Track Your Order!',
+  'follow-ig': 'Follow @yardmicrowaves',
+  'leave-review': 'Leave a review',
+  'our-story': 'Our Story',
+};
+
+async function main() {
+  browser = await chromium.launch();
+  page = await browser.newPage({ deviceScaleFactor: 2 });
+
+  console.log('rendering theme assets → build/assets');
+
+  // --- page texture (theme body background) ---------------------------------
+  await shot('paper-bg', `<div style="width:600px;height:900px;background:${C.paper} url('${asset('ym-page-texture.jpg')}') center top / cover no-repeat"></div>`,
+    '', { w: 600, h: 900, jpg: true, quality: 70 });
+
+  // --- logos ----------------------------------------------------------------
+  // Badge: the theme's cart-header treatment — orange rounded rect, rotated
+  // -2°, white ticket logo on top (wordmark reads orange through the cutout).
+  await shot('badge-logo', `<div style="display:inline-block;padding:10px 16px;background:${C.orange};border-radius:10px;transform:rotate(-2deg);margin:6px 8px;">
+      <div style="width:150px;line-height:0">${logoSvg}</div></div>`, '', { w: 200 });
+  await shot('logo-white', `<div style="width:170px;line-height:0;margin:2px">${logoSvg}</div>`, '', { w: 176 });
+
+  // --- nav: "The SHOP" / "Our STORY" (Milenia + Bananas expanded, olive) ----
+  const navCss = `.n{text-align:center;color:${C.olive};padding:2px 4px}.sm{font-family:Milenia;font-size:22px;line-height:1}.bg{font-family:BananasExp;font-weight:700;font-size:30px;line-height:.95;text-transform:uppercase;margin-top:-2px;letter-spacing:.02em}`;
+  await typeShot('nav-shop', `<div class="n"><div class="sm">The</div><div class="bg">Shop</div></div>`, navCss);
+  await typeShot('nav-story', `<div class="n"><div class="sm">Our</div><div class="bg">Story</div></div>`, navCss);
+
+  // --- headlines (Milenia script, olive, like .ym-pioneers__title) ----------
+  for (const [k, text] of Object.entries(HEADLINES)) {
+    await typeShot(`h-${k}`, `<div class="t">${text}</div>`,
+      `.t{font-family:Milenia;font-size:48px;line-height:1.08;color:${C.olive};text-align:center;padding:6px 10px}`, { maxW: 500 });
+  }
+
+  // --- button labels (Milenia white; pill is HTML so alt text degrades) -----
+  for (const [k, text] of Object.entries(BUTTONS)) {
+    await typeShot(`b-${k}`, `<div class="t">${text}</div>`,
+      `.t{font-family:Milenia;font-size:26px;line-height:1;color:#fff;white-space:nowrap;padding:4px 2px}`);
+  }
+  // Full red pill as one image too (for clients that drop bgcolor on <td>)
+  for (const [k, text] of Object.entries(BUTTONS)) {
+    await typeShot(`pill-${k}`, `<div class="p">${text}</div>`,
+      `.p{display:inline-block;font-family:Milenia;font-size:26px;line-height:1;color:#fff;white-space:nowrap;background:${C.red};border-radius:20px;padding:14px 40px 16px}`);
+  }
+
+  // --- hero: smoker still + white ticket logo + torn paper edge --------------
+  await shot('hero-smoker', `
+    <div style="position:absolute;inset:0;background:#111 url('${asset('ym-hero-smoker.png')}') center / cover no-repeat"></div>
+    <div style="position:absolute;inset:0;background:rgba(0,0,0,.18)"></div>
+    <div style="position:absolute;left:50%;top:46%;width:220px;transform:translate(-50%,-50%);line-height:0;filter:drop-shadow(0 3px 8px rgba(0,0,0,.5))">${logoSvg}</div>
+    <img src="${asset('ym-torn-edge-merged.png')}" style="position:absolute;left:-2%;bottom:-6px;width:104%;height:auto;display:block">
+  `, '', { w: 600, h: 330 });
+
+  // --- product showcase: shirts on butcher paper with marker callouts --------
+  await shot('showcase', `
+    <img src="${asset('ym-butcher-paper.png')}" style="position:absolute;left:-70px;top:70px;width:720px;transform:rotate(-6deg)">
+    <img src="${asset('ym-rubplug-back-full.png')}" style="position:absolute;left:10px;top:70px;width:340px;transform:rotate(-4deg);filter:drop-shadow(0 10px 18px rgba(0,0,0,.28))">
+    <img src="${asset('ym-smokesig-back-full.png')}" style="position:absolute;left:280px;top:180px;width:330px;transform:rotate(4deg);filter:drop-shadow(0 10px 18px rgba(0,0,0,.28))">
+    <img src="${asset('ym-sparkle-1.png')}" style="position:absolute;left:12px;top:6px;width:50px">
+    <img src="${asset('ym-pellets-sm.png')}" style="position:absolute;left:20px;bottom:16px;width:56px">
+    <div class="mk" style="left:392px;top:56px">Relaxed<br>fit</div>
+    <svg class="ar" style="left:366px;top:82px" width="40" height="30" viewBox="0 0 40 30"><path d="M38 4 C28 2, 12 8, 4 24" fill="none" stroke="${C.olive}" stroke-width="2.5" stroke-linecap="round"/><path d="M2 16 L4 25 L13 23" fill="none" stroke="${C.olive}" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+    <div class="mk" style="left:508px;top:146px">Crew<br>neck</div>
+    <svg class="ar" style="left:482px;top:172px" width="40" height="30" viewBox="0 0 40 30"><path d="M38 4 C28 2, 12 8, 4 24" fill="none" stroke="${C.olive}" stroke-width="2.5" stroke-linecap="round"/><path d="M2 16 L4 25 L13 23" fill="none" stroke="${C.olive}" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+    <div class="mk" style="left:132px;top:486px">Heavy<br>weight</div>
+    <svg class="ar" style="left:196px;top:470px;transform:scaleX(-1) rotate(40deg)" width="40" height="30" viewBox="0 0 40 30"><path d="M38 4 C28 2, 12 8, 4 24" fill="none" stroke="${C.olive}" stroke-width="2.5" stroke-linecap="round"/><path d="M2 16 L4 25 L13 23" fill="none" stroke="${C.olive}" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+  `, `.mk{position:absolute;font-family:Marker;font-size:16px;line-height:1.05;text-transform:uppercase;color:${C.olive};text-align:center;text-shadow:0 0 6px ${C.paper},0 0 10px ${C.paper}}.ar{position:absolute;filter:drop-shadow(0 0 3px ${C.paper})}`,
+  { w: 600, h: 580 });
+
+  // --- quality banner band (sparkles + Bananas uppercase olive) --------------
+  await shot('quality-band', `
+    <img src="${asset('ym-sparkle-2.png')}" style="position:absolute;right:28px;top:-4px;width:44px">
+    <img src="${asset('ym-pellets-sm.png')}" style="position:absolute;left:18px;bottom:-6px;width:40px">
+    <div style="padding:26px 70px 22px;text-align:center;font-family:Bananas;font-weight:600;font-size:15px;line-height:1.45;letter-spacing:.05em;text-transform:uppercase;color:${C.olive}">
+      Quality beyond compare. Preshrunk for perfection. Just like your brisket, our shirts exceed expectations. Guaranteed.
+    </div>`, '', { w: 600 });
+
+  // --- free-shipping sticker (starburst) ------------------------------------
+  await shot('freeship', `
+    <img src="${asset('ym-cart-starburst.png')}" style="position:absolute;inset:0;width:170px;height:170px">
+    <div style="position:absolute;inset:0;display:flex;align-items:center;justify-content:center;transform:rotate(-8deg);font-family:BananasExp;font-weight:700;font-size:17px;line-height:1.05;text-transform:uppercase;color:#fff;text-align:center;padding:0 26px">Free shipping on $50+</div>
+  `, '', { w: 170, h: 170 });
+
+  // --- recipe card (tagline section) with marker ingredients -----------------
+  const ING = ['Relaxed fit', 'Heavy weight — 100% combed cotton', 'Crew neck with ribbing', 'Shoulder-to-shoulder tape', 'Preshrunk to minimize shrinkage', 'Double needle hems'];
+  await shot('recipe-card', `
+    <img src="${asset('ym-recipe-card.png')}" style="display:block;width:600px;height:auto">
+    ${ING.map((t, i) => `<div class="ing" style="top:${72 + i * 24.2}px">${t}</div>`).join('')}
+  `, `.ing{position:absolute;left:112px;font-family:Marker;font-size:14px;line-height:1;color:${C.olive};text-transform:uppercase;white-space:nowrap}`,
+  { w: 600 });
+  await shot('tagline-brisket', `<img src="${asset('ym-tagline-brisket.png')}" style="display:block;width:260px;height:auto">`, '', { w: 260 });
+
+  // --- footer transition: paper tears away to reveal the dark footer ---------
+  await shot('torn-to-dark', `
+    <div style="position:absolute;left:0;right:0;top:44px;bottom:0;background:${C.dark}"></div>
+    <img src="${asset('ym-torn-edge-merged.png')}" style="position:absolute;left:-2%;top:-2px;width:104%;display:block">
+  `, '', { w: 600, h: 100 });
+
+  // --- HOT LINKS heading + sausage chain split into three linkable thirds ---
+  await typeShot('hotlinks-heading', `<div class="t">Hot Links</div>`,
+    `.t{font-family:BananasExp;font-weight:700;font-size:34px;line-height:1;letter-spacing:.05em;text-transform:uppercase;color:${C.orange};padding:4px 6px}`);
+  const chain = asset('ym-hot-links-chain.png');
+  const socials = [['instagram', 'ym-icon-instagram.png', 0], ['facebook', 'ym-icon-facebook.png', 1], ['tiktok', 'ym-icon-tiktok.png', 2]];
+  for (const [name, icon, i] of socials) {
+    await shot(`hotlink-${name}`, `
+      <img src="${chain}" style="position:absolute;left:${-i * 196}px;top:30px;width:588px;height:auto">
+      <img src="${asset(icon)}" style="position:absolute;left:50%;top:38px;transform:translateX(-50%);height:22px;width:auto;filter:drop-shadow(0 1px 1px rgba(0,0,0,.5))">
+    `, '', { w: 196, h: 100 });
+  }
+
+  // --- straight copies / simple crops ---------------------------------------
+  copyFileSync(resolve(THEME_ASSETS, 'ym-mascot.png'), resolve(OUT, 'mascot.png'));
+  manifest['mascot'] = { file: 'mascot.png', w: 250, h: 180 };
+  await shot('story-collage', `<img src="${asset('ym-story-collage.png')}" style="display:block;width:320px;height:auto">`, '', { w: 320 });
+  await shot('pioneers-photo', `<img src="${asset('ym-pioneers-photo.png')}" style="display:block;width:300px;height:auto">`, '', { w: 300 });
+  await shot('pellets', `<img src="${asset('ym-pellets-cluster.png')}" style="display:block;width:110px;height:auto">`, '', { w: 110 });
+  await shot('icon-smoke', `<img src="${asset('ym-icon-smoke.png')}" style="display:block;width:42px;height:auto">`, '', { w: 42 });
+  // review star (orange, matches the starburst)
+  await shot('star', `<svg width="40" height="40" viewBox="0 0 24 24"><path d="M12 2.5l2.9 6.1 6.7.8-4.9 4.6 1.3 6.6L12 17.3l-6 3.3 1.3-6.6L2.4 9.4l6.7-.8z" fill="${C.orange}" stroke="${C.redDark}" stroke-width=".6" stroke-linejoin="round"/></svg>`, '', { w: 40, h: 40 });
+
+  writeFileSync(resolve(OUT, 'manifest.json'), JSON.stringify(manifest, null, 1));
+  await browser.close();
+  console.log(`done: ${Object.keys(manifest).length} assets`);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/email/templates.json
+++ b/email/templates.json
@@ -1,0 +1,62 @@
+{
+ "welcome-1-new": {
+  "id": "QR3AJm",
+  "name": "YM Theme - Welcome #1 - New Subscriber (20% Off)",
+  "hash": "d93a53c6efa1"
+ },
+ "welcome-1-existing": {
+  "id": "UrTmKj",
+  "name": "YM Theme - Welcome #1 - Existing Customer",
+  "hash": "962109535b0f"
+ },
+ "welcome-2-follow": {
+  "id": "TNSj8G",
+  "name": "YM Theme - Welcome #2 - Follow Us",
+  "hash": "5602a709b82b"
+ },
+ "review-request": {
+  "id": "RprnZA",
+  "name": "YM Theme - Review Request",
+  "hash": "99d301ba31a2"
+ },
+ "review-reminder": {
+  "id": "XW7SqT",
+  "name": "YM Theme - Review Reminder",
+  "hash": "ba18734c1106"
+ },
+ "shipping-confirmation": {
+  "id": "Xj6PNg",
+  "name": "YM Theme - Shipping Confirmation",
+  "hash": "846d2f29ce90"
+ },
+ "order-confirmation": {
+  "id": "T7e2aF",
+  "name": "YM Theme - Order Confirmation",
+  "hash": "faf243541b0f"
+ },
+ "abandoned-cart-1": {
+  "id": "RRbUVr",
+  "name": "YM Theme - Abandoned Cart #1",
+  "hash": "6b405d32651f"
+ },
+ "abandoned-cart-2": {
+  "id": "XetzsS",
+  "name": "YM Theme - Abandoned Cart #2",
+  "hash": "f81384e0ef18"
+ },
+ "abandoned-cart-3": {
+  "id": "RLyEA3",
+  "name": "YM Theme - Abandoned Cart #3 (15% Off)",
+  "hash": "e631a473fb21"
+ },
+ "browse-abandonment-1": {
+  "id": "R9xBXq",
+  "name": "YM Theme - Browse Abandonment #1",
+  "hash": "4795b9ca0cf1"
+ },
+ "browse-abandonment-2": {
+  "id": "SVXvtT",
+  "name": "YM Theme - Browse Abandonment #2",
+  "hash": "d2fdd0eac874"
+ }
+}

--- a/email/templates.json
+++ b/email/templates.json
@@ -2,61 +2,61 @@
  "welcome-1-new": {
   "id": "QR3AJm",
   "name": "YM Theme - Welcome #1 - New Subscriber (20% Off)",
-  "hash": "d93a53c6efa1"
+  "hash": "454949b17aa9"
  },
  "welcome-1-existing": {
   "id": "UrTmKj",
   "name": "YM Theme - Welcome #1 - Existing Customer",
-  "hash": "962109535b0f"
+  "hash": "b74898962b5f"
  },
  "welcome-2-follow": {
   "id": "TNSj8G",
   "name": "YM Theme - Welcome #2 - Follow Us",
-  "hash": "5602a709b82b"
+  "hash": "6e18a724dc98"
  },
  "review-request": {
   "id": "RprnZA",
   "name": "YM Theme - Review Request",
-  "hash": "99d301ba31a2"
+  "hash": "40869992f2f2"
  },
  "review-reminder": {
   "id": "XW7SqT",
   "name": "YM Theme - Review Reminder",
-  "hash": "ba18734c1106"
+  "hash": "217ab3ca222f"
  },
  "shipping-confirmation": {
   "id": "Xj6PNg",
   "name": "YM Theme - Shipping Confirmation",
-  "hash": "846d2f29ce90"
+  "hash": "1d22193eac18"
  },
  "order-confirmation": {
   "id": "T7e2aF",
   "name": "YM Theme - Order Confirmation",
-  "hash": "faf243541b0f"
+  "hash": "0ce3521b37a3"
  },
  "abandoned-cart-1": {
   "id": "RRbUVr",
   "name": "YM Theme - Abandoned Cart #1",
-  "hash": "6b405d32651f"
+  "hash": "bfcb7e66d183"
  },
  "abandoned-cart-2": {
   "id": "XetzsS",
   "name": "YM Theme - Abandoned Cart #2",
-  "hash": "f81384e0ef18"
+  "hash": "b16df460d7a6"
  },
  "abandoned-cart-3": {
   "id": "RLyEA3",
   "name": "YM Theme - Abandoned Cart #3 (15% Off)",
-  "hash": "e631a473fb21"
+  "hash": "b0a0d5466930"
  },
  "browse-abandonment-1": {
   "id": "R9xBXq",
   "name": "YM Theme - Browse Abandonment #1",
-  "hash": "4795b9ca0cf1"
+  "hash": "9466b574777d"
  },
  "browse-abandonment-2": {
   "id": "SVXvtT",
   "name": "YM Theme - Browse Abandonment #2",
-  "hash": "d2fdd0eac874"
+  "hash": "f94627625733"
  }
 }


### PR DESCRIPTION
## What

A \`email/\` pipeline that builds the Yard Microwaves Klaviyo email set from the **same assets and fonts the theme ships** — no Figma exports, no hand-cut PNGs.

- \`render-assets.mjs\` — Playwright renders Milenia / Bananas / Permanent Marker type to PNG (email clients can't load web fonts) and composes the smoker hero, butcher-paper showcase with marker callouts, recipe card, quality band, free-shipping starburst, torn edge → dark footer, and the HOT LINKS sausage chain, all from \`assets/ym-*\`.
- \`klaviyo.mjs upload|push|render\` — uploads to Klaviyo's image library as data URIs (hash-deduped; Klaviyo has no image delete), creates/updates the 12 \`YM Theme - …\` templates in place, renders them with sample event data.
- \`build.mjs\` — one shared skeleton (header → Milenia headline → olive lede → editable Klaviyo region → red Milenia pill → feature → quality band → footer), 12 templates: Welcome ×3, Review ×2, Shipping, Order, Abandoned Cart ×3, Browse ×2.
- \`preview.mjs\` — desktop + mobile screenshots + contact sheet.

\`npm run all\` reproduces everything; \`assets.json\` / \`templates.json\` pin CDN urls and template ids.

## Not touched

The existing \`YM - …\` templates (Figma-based set) are left as-is; flows still point at them. Swapping is a per-flow change in Klaviyo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)